### PR TITLE
Remove typ requirement

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,9 +215,6 @@
               refer to a key in a <a>DID document</a>, or can be the identifier
               of a key inside a JWKS.
             </li>
-            <li>
-              <code>typ</code>, if present, MUST be set to <code>JWT</code>.
-            </li>
           </ul>
 
           <p>
@@ -376,7 +373,6 @@
           >
 {
 "alg": "RS256",
-"typ": "JWT",
 "kid": "did:example:abfe13f712120431c276e12ecab#keys-1"
 }
           </pre>
@@ -454,7 +450,6 @@ txJy6M1-lD7a5HTzanYTWBPAUHDZGyGKXdJw-W_x0IWChBzI8t3kpG253fg6V3tPgHeKXE94fz_QpYfg
           >
 {
 "alg": "RS256",
-"typ": "JWT",
 "kid": "did:example:ebfeb1f712ebc6f1c276e12ec21#keys-1"
 }
           </pre>


### PR DESCRIPTION
This PR removes the `typ` requirement.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jwt/pull/10.html" title="Last updated on Aug 31, 2022, 2:09 PM UTC (1e07f7e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jwt/10/bfcd55e...1e07f7e.html" title="Last updated on Aug 31, 2022, 2:09 PM UTC (1e07f7e)">Diff</a>