### PR TITLE
Propose "instead of" in terms of media type

### DIFF
--- a/index.html
+++ b/index.html
@@ -628,13 +628,13 @@ BjYgP62KvhIvW8BbkGUelYMetA
         </p>
         <ol>
           <li>
-            Completing the mapping for <a href="#in-addition-to">In Addition To...</a>.
+            Complete the mapping for <a href="#in-addition-to">In Addition To...</a>.
           </li>
           <li>
-            Removing any properties from the <code>application/credential+ld+json</code> that were mapped.
+            Remove any properties from the <code>application/credential+ld+json</code> that were mapped.
           </li>
           <li>
-            Setting the resulting object to be the <code>vc</code> member of the claim set.
+            Set the resulting object to be the <code>vc</code> member of the claim set.
           </li>
         </ol>
 

--- a/index.html
+++ b/index.html
@@ -519,12 +519,14 @@ BjYgP62KvhIvW8BbkGUelYMetA
       </section>
     </section>
 
+    <section id="version-1.1">
+      <h2>Version 1.1</h2>
     <section id="production">
       <h2>Production</h2>
 
       <p>
         This section describes how to produce a VC-JWT encoded
-        <code>VerifiableCredential</code> from a <code>Credential</code>.
+        <code>VerifiableCredential</code> from an object of media type <code>application/credential+ld+json</code>.
       </p>
 
       <p class="advisment">
@@ -540,14 +542,14 @@ BjYgP62KvhIvW8BbkGUelYMetA
 
         <p>
           There are several members (claims) of the
-          <code>Credential</code> which will need to be translated to their JOSE
+          <code>application/credential+ld+json</code> which will need to be translated to their JOSE
           form, and included next to the <code>vc</code> or
           <code>vp</code> member in the JWT Claims Set. 
           We refer to the JWT Claims Set as <code>payload</code> in this section.
         </p>
 
         <p>
-          If a member is not present in the <code>Credential</code> it MUST NOT
+          If a member is not present in the <code>application/credential+ld+json</code> it MUST NOT
           be present in the <code>VerifiableCredential</code> as either a claim
           in the payload or a claim in the <code>vc</code> attribute of the
           payload.
@@ -556,7 +558,7 @@ BjYgP62KvhIvW8BbkGUelYMetA
         <p>
           We start with an empty header, and payload objects, and we add members
           to the header and the payload based on the content in the
-          <code>Credential</code>.
+          <code>application/credential+ld+json</code>.
         </p>
 
         <section>
@@ -621,10 +623,30 @@ BjYgP62KvhIvW8BbkGUelYMetA
 
       <section>
         <h3>Instead of...</h3>
-        <p class="issue">This section needs to be defined.</p>
+        <p>
+          This representation can be obtained by:
+        </p>
+        <ol>
+          <li>
+            Completing the mapping for <a href="#in-addition-to">In Addition To...</a>.
+          </li>
+          <li>
+            Removing any properties from the <code>application/credential+ld+json</code> that were mapped.
+          </li>
+          <li>
+            Setting the resulting object to be the <code>vc</code> member of the claim set.
+          </li>
+        </ol>
+
+        <p class="note">
+          The object value for the <code>vc</code> property, 
+          when <a href="#instead-of">Instead of...</a> production rules have been applied, 
+          is not of media type <code>application/credential+ld+json</code>.
+        </p>
+
       </section>
     </section>
-
+    </section>
     <section>
       <h2>Privacy Considerations</h2>
     </section>

--- a/index.html
+++ b/index.html
@@ -624,7 +624,7 @@ BjYgP62KvhIvW8BbkGUelYMetA
       <section>
         <h3>Instead of...</h3>
         <p>
-          This representation can be obtained by:
+          The following steps are one way to obtain this representation:
         </p>
         <ol>
           <li>


### PR DESCRIPTION
This pull request leverages  https://github.com/w3c/vc-data-model/pull/1000 

It defines the "instead of" production rules in terms of the `application/credential+ld+json` media type.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 522  :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 20, 2023, 11:35 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fvc-jwt%2F36e99ce8ca5fccfe0493610e6582cff3fe803693%2Findex.html%3FisPreview%3Dtrue)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/vc-jwt%2341.)._
</details>
