### PR TITLE
Revert shortening of media type

### DIFF
--- a/index.html
+++ b/index.html
@@ -736,7 +736,7 @@ BjYgP62KvhIvW8BbkGUelYMetA
       </p>
       <section>
         <h2>Credential Metadata</h2>
-        <p><a data-cite="rfc7519#section-5.1">typ</a> MUST use the content type <code>vc+jwt</code>.</p>
+        <p><a data-cite="rfc7519#section-5.1">typ</a> MUST use the content type <code>verifiable-credential+jwt</code>.</p>
         <p class="issue" data-number="45"></p>
         <p>If present, <a data-cite="rfc7519#section-5.2">cty</a> SHOULD use the content type <code>credential-claims-set+json</code>.</p>
         <aside
@@ -800,9 +800,9 @@ BjYgP62KvhIvW8BbkGUelYMetA
     <section class="appendix informative">
 <h2>IANA Considerations</h2>
 <section id="vc-jwt-media-type">
-  <h2>The <code>application/vc+jwt</code> Media Type</h2>
+  <h2>The <code>application/verifiable-credential+jwt</code> Media Type</h2>
   <p>
-    This specification registers the <code>application/vc+jwt</code> MIME Media Type specifically for
+    This specification registers the <code>application/verifiable-credential+jwt</code> MIME Media Type specifically for
     identifying a <a data-cite="rfc7519#section-3">JWT</a> conforming to the Verifiable Credentials JWT format in the `typ` header.
   </p>
   <table>
@@ -812,7 +812,7 @@ BjYgP62KvhIvW8BbkGUelYMetA
     </tr>
     <tr>
       <td>Subtype name: </td>
-      <td>application/vc+jwt</td>
+      <td>application/verifiable-credential+jwt</td>
     </tr>
     <tr>
       <td>Required parameters: </td>
@@ -821,7 +821,7 @@ BjYgP62KvhIvW8BbkGUelYMetA
     <tr>
       <td>Encoding considerations: </td>
       <td>
-        <code>application/vc+jwt</code> values are encoded
+        <code>application/verifiable-credential+jwt</code> values are encoded
         as a series of base64url encoded values (some of which may be the
         empty string) each separated from the next by a single period
         ('.') character.


### PR DESCRIPTION
As requested by @brentzundel on https://github.com/w3c/vc-jwt/pull/50


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jwt/pull/59.html" title="Last updated on Mar 2, 2023, 9:28 PM UTC (e583759)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jwt/59/93385bc...e583759.html" title="Last updated on Mar 2, 2023, 9:28 PM UTC (e583759)">Diff</a>