### PR TITLE
Add context integrity approach for VC-JWTs

### DIFF
--- a/index.html
+++ b/index.html
@@ -399,8 +399,8 @@ section of the JWT specification for privacy guidance.
   <section>
     <h2>Context Integrity</h2>
     <p>
-      In some cases is is desireable to know that the contents of the
-      context(s) utilized in the verifiable credential is the same as
+      In some cases it is desirable to know that the contents of the
+      context(s) utilized in the verifiable credential are the same as
       used by both the issuer and verifier.  
     </p>
     <p>

--- a/index.html
+++ b/index.html
@@ -363,36 +363,83 @@ section of the JWT specification for privacy guidance.
     It is important to carefully consider these factors to ensure the security 
     and integrity of Verifiable Credentials when implemented using JWTs.
   </p>
-  <p>
-    When implementing VC-JWTs, it is essential to address all security issues relevant 
-    to broad cryptographic applications. This especially includes protecting the user's
-    asymmetric private and symmetric secret keys, as well as employing countermeasures 
-    against various attacks. Failure to adequately address these issues could compromise 
-    the security and integrity of Verifiable Credentials, potentially leading to unauthorized 
-    access, modification, or disclosure of sensitive information. 
-  </p>
-  <p>
-    Implementers are advised to follow best practices and established cryptographic standards to ensure 
-    the secure handling of keys and other sensitive data. 
-    Additionally, conduct regular security assessments and audits to identify and 
-    address any vulnerabilities or threats.
-  </p>
-  <p>
-    Follow all security considerations outlined in [[rfc7515]] and [[rfc7519]].
-  </p>
-  <p>
-    When utilizing JSON-LD, take special care around remote retrieval of contexts and follow the
-    additional security considerations noted in [[json-ld11]].
-  </p>
-  <p>
-    As noted in [[rfc7515]] when utilizing JSON [[rfc7159]], strict validation is a security
-    requirement. If malformed JSON is received, it may be impossible to reliably interpret the 
-    producer's intent, potentially leading to ambiguous or exploitable situations.
-    To prevent these risks, it is essential to use a JSON parser that strictly validates the syntax 
-    of all input data. It is essential that any JSON inputs that do not conform to the JSON-text syntax defined in [[rfc7159]]
-    be rejected in their entirety by JSON parsers. Failure to reject invalid input could compromise 
-    the security and integrity of Verifiable Credentials.
-  </p>
+  <section>
+    <h2>General Considerations</h2>
+    <p>
+      When implementing VC-JWTs, it is essential to address all security issues relevant 
+      to broad cryptographic applications. This especially includes protecting the user's
+      asymmetric private and symmetric secret keys, as well as employing countermeasures 
+      against various attacks. Failure to adequately address these issues could compromise 
+      the security and integrity of Verifiable Credentials, potentially leading to unauthorized 
+      access, modification, or disclosure of sensitive information. 
+    </p>
+    <p>
+      Implementers are advised to follow best practices and established cryptographic standards to ensure 
+      the secure handling of keys and other sensitive data. 
+      Additionally, conduct regular security assessments and audits to identify and 
+      address any vulnerabilities or threats.
+    </p>
+    <p>
+      Follow all security considerations outlined in [[rfc7515]] and [[rfc7519]].
+    </p>
+    <p>
+      When utilizing JSON-LD, take special care around remote retrieval of contexts and follow the
+      additional security considerations noted in [[json-ld11]].
+    </p>
+    <p>
+      As noted in [[rfc7515]] when utilizing JSON [[rfc7159]], strict validation is a security
+      requirement. If malformed JSON is received, it may be impossible to reliably interpret the 
+      producer's intent, potentially leading to ambiguous or exploitable situations.
+      To prevent these risks, it is essential to use a JSON parser that strictly validates the syntax 
+      of all input data. It is essential that any JSON inputs that do not conform to the JSON-text syntax defined in [[rfc7159]]
+      be rejected in their entirety by JSON parsers. Failure to reject invalid input could compromise 
+      the security and integrity of Verifiable Credentials.
+    </p>
+  </section>
+  <section>
+    <h2>Context Integrity</h2>
+    <p>
+      In some cases is is desireable to know that the version of the
+      context(s) utilized in the verifiable credential is the same as
+      used by both the issuer and verifier.  
+    </p>
+    <p>
+      To validate that a context included in a Verifiable Credential is
+      the same at verification time as at issuing time an implementer
+      MAY include a property named <code>contextIntegrity</code> that
+      stores an array of objects that describe additional integrity
+      metadata about the context. Each object in the
+      <code>contextIntegrity</code> array MUST contain the following:
+      the URL to the context named <code>context</code>, a
+      <code>timestamp</code>
+      that indicates when the context was retrieved and hashed, the
+      <code>hash</code>
+      of the context, and the <code>method</code> which indicates what
+      hashing algorithm was used as listed as the 'Hash Name String'
+      property from the <a
+      href="https://www.iana.org/assignments/named-information/named-information.xhtml">IANA
+      Named Information Hash Algorithm Registry</a>.  
+      The <code>timestamp</code> property MUST be a string value of an
+      [[XMLSCHEMA11-2]] combined date-time string. An implementer may
+      include other fields in each object.
+    </p>
+    <p>
+      <aside
+        class="example"
+        title="context integrity"
+      >
+        <p>An example of a context integrity object</p>
+        <pre>
+          "contextIntegrity": [{
+            "context":"https://example.org/v1/context", 
+            "timestamp": "1971/01/01 00:00:00", 
+            "hash": "0c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004", 
+            "method": "sha3-384"  
+          }]
+        </pre>
+      </aside>
+    </p>
+  </section>
 </section>
 
     <section class="appendix informative">

--- a/index.html
+++ b/index.html
@@ -432,7 +432,7 @@ section of the JWT specification for privacy guidance.
         <pre>
           "contextIntegrity": [{
             "context":"https://example.org/v1/context", 
-            "timestamp": "1971/01/01 00:00:00", 
+            "timestamp": "2020-01-01T19:23:24Z", 
             "hash": "0c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004", 
             "method": "sha3-384"  
           }]

--- a/index.html
+++ b/index.html
@@ -399,7 +399,7 @@ section of the JWT specification for privacy guidance.
   <section>
     <h2>Context Integrity</h2>
     <p>
-      In some cases is is desireable to know that the version of the
+      In some cases is is desireable to know that the contents of the
       context(s) utilized in the verifiable credential is the same as
       used by both the issuer and verifier.  
     </p>
@@ -408,11 +408,17 @@ section of the JWT specification for privacy guidance.
       the same at verification time as at issuing time an implementer
       MAY include a property named <code>contextIntegrity</code> that
       stores an array of objects that describe additional integrity
-      metadata about the context. Each object in the
+      metadata about each context used by the VC. If
+      <code>contextIntegrity</code>
+      is present there MUST be an object in the array for each remote
+      context.
+    </p>
+    <p>
+      Each object in the
       <code>contextIntegrity</code> array MUST contain the following:
       the URL to the context named <code>context</code>, a
       <code>timestamp</code>
-      that indicates when the context was retrieved and hashed, the
+      that indicates the time at which the hash was computed, the
       <code>hash</code>
       of the context, and the <code>method</code> which indicates what
       hashing algorithm was used as listed as the 'Hash Name String'
@@ -422,6 +428,23 @@ section of the JWT specification for privacy guidance.
       The <code>timestamp</code> property MUST be a string value of an
       [[XMLSCHEMA11-2]] combined date-time string. An implementer may
       include other fields in each object.
+    </p>
+    <p>
+      Implementers should consult appropriate sources, such as the <a
+      href="https://www.iana.org/assignments/named-information/named-information.xhtml">IANA
+      Named Information Hash Algorithm Registry</a> to ensure that they
+      are chosing a current and reliable hash algorithm.  At the time of
+      this writing `sha-256` should be considered the minimum strength
+      hash algorithm for use by implemnters.
+    </p>
+    <p class="note">
+      If at a later date subresource integrity as defined in [[SRI]] is
+      adopted into the [[JSON-LD]] specification as noted in that
+      specifications <a
+      href="https://www.w3.org/TR/json-ld11/#security">current security
+      considerations</a> of that specification, this hash in the VC can
+      serve as an additional check towards ensuring that a cached
+      context used when issuing the VC matches the remote resource.
     </p>
     <p>
       <aside


### PR DESCRIPTION
With verifiable credentials, or any signed JSON-LD it is often a desirable property to know that the context you are working with is the same on both ends, or if there has been a change.  This PR adds an optional ability to provide the hash of contexts used at issuance time.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mesur-io/vc-jwt/pull/90.html" title="Last updated on Jun 2, 2023, 7:03 PM UTC (2b724aa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jwt/90/e3ecd2e...mesur-io:2b724aa.html" title="Last updated on Jun 2, 2023, 7:03 PM UTC (2b724aa)">Diff</a>